### PR TITLE
Add toggle to export playlist for older FT

### DIFF
--- a/src/renderer/components/data-settings/data-settings.js
+++ b/src/renderer/components/data-settings/data-settings.js
@@ -1029,7 +1029,7 @@ export default defineComponent({
 
     exportPlaylistsForOlderVersions: async function () {
       const dateStr = getTodayDateStrLocalTimezone()
-      const exportFileName = 'freetube-playlists-for-single-favorites-playlist-' + dateStr + '.db'
+      const exportFileName = 'freetube-playlists-as-single-favorites-playlist-' + dateStr + '.db'
 
       const options = {
         defaultPath: exportFileName,

--- a/src/renderer/components/data-settings/data-settings.vue
+++ b/src/renderer/components/data-settings/data-settings.vue
@@ -51,6 +51,7 @@
         :compact="true"
         :default-value="shouldExportPlaylistForOlderVersions"
         :tooltip="$t('Settings.Data Settings.Export Playlists For Older FreeTube Versions.Tooltip')"
+        :tooltip-allow-newlines="true"
         @change="shouldExportPlaylistForOlderVersions = !shouldExportPlaylistForOlderVersions"
       />
     </ft-flex-box>

--- a/src/renderer/components/data-settings/data-settings.vue
+++ b/src/renderer/components/data-settings/data-settings.vue
@@ -42,7 +42,16 @@
       />
       <ft-button
         :label="$t('Settings.Data Settings.Export Playlists')"
-        @click="exportPlaylists"
+        @click="exportPlaylistsForOlderVersionsSometimes"
+      />
+    </ft-flex-box>
+    <ft-flex-box>
+      <ft-toggle-switch
+        :label="$t('Settings.Data Settings.Export Playlists For Older FreeTube Versions.Label')"
+        :compact="true"
+        :default-value="shouldExportPlaylistForOlderVersions"
+        :tooltip="$t('Settings.Data Settings.Export Playlists For Older FreeTube Versions.Tooltip')"
+        @change="shouldExportPlaylistForOlderVersions = !shouldExportPlaylistForOlderVersions"
       />
     </ft-flex-box>
     <ft-prompt

--- a/src/renderer/components/ft-toggle-switch/ft-toggle-switch.js
+++ b/src/renderer/components/ft-toggle-switch/ft-toggle-switch.js
@@ -30,7 +30,11 @@ export default defineComponent({
     tooltipPosition: {
       type: String,
       default: 'bottom-left'
-    }
+    },
+    tooltipAllowNewlines: {
+      type: Boolean,
+      default: false,
+    },
   },
   data: function () {
     return {

--- a/src/renderer/components/ft-toggle-switch/ft-toggle-switch.vue
+++ b/src/renderer/components/ft-toggle-switch/ft-toggle-switch.vue
@@ -29,6 +29,7 @@
         class="selectTooltip"
         :position="tooltipPosition"
         :tooltip="tooltip"
+        :allow-newlines="tooltipAllowNewlines"
       />
     </label>
   </div>

--- a/src/renderer/components/ft-tooltip/ft-tooltip.css
+++ b/src/renderer/components/ft-tooltip/ft-tooltip.css
@@ -93,13 +93,11 @@
 }
 
 .text.allowNewlines {
-  white-space: pre-wrap;
+  white-space: pre;
   text-align: start;
-
-  @media only screen and (min-width: 1000px) {
-    /* Enough space to NOT wrap */
-    white-space: pre;
-  }
+}
+.text.allowNewlines.wrap {
+  white-space: pre-wrap;
 }
 
 .tooltip {

--- a/src/renderer/components/ft-tooltip/ft-tooltip.css
+++ b/src/renderer/components/ft-tooltip/ft-tooltip.css
@@ -94,6 +94,7 @@
 
 .text.allowNewlines {
   white-space: pre;
+  text-align: start;
 }
 
 .tooltip {

--- a/src/renderer/components/ft-tooltip/ft-tooltip.css
+++ b/src/renderer/components/ft-tooltip/ft-tooltip.css
@@ -95,11 +95,11 @@
 .text.allowNewlines {
   white-space: pre-wrap;
   text-align: start;
+  inline-size: 55vw;
+}
 
-  @media only screen and (min-width: 1000px) {
-    /* Enough space to NOT wrap */
-    white-space: pre;
-  }
+@media only screen and (max-width: 1100px) {
+  inline-size: 40vw;
 }
 
 .tooltip {

--- a/src/renderer/components/ft-tooltip/ft-tooltip.css
+++ b/src/renderer/components/ft-tooltip/ft-tooltip.css
@@ -93,11 +93,13 @@
 }
 
 .text.allowNewlines {
-  white-space: pre;
-  text-align: start;
-}
-.text.allowNewlines.wrap {
   white-space: pre-wrap;
+  text-align: start;
+
+  @media only screen and (min-width: 1000px) {
+    /* Enough space to NOT wrap */
+    white-space: pre;
+  }
 }
 
 .tooltip {

--- a/src/renderer/components/ft-tooltip/ft-tooltip.css
+++ b/src/renderer/components/ft-tooltip/ft-tooltip.css
@@ -93,8 +93,13 @@
 }
 
 .text.allowNewlines {
-  white-space: pre;
+  white-space: pre-wrap;
   text-align: start;
+
+  @media only screen and (min-width: 1000px) {
+    /* Enough space to NOT wrap */
+    white-space: pre;
+  }
 }
 
 .tooltip {

--- a/src/renderer/components/ft-tooltip/ft-tooltip.css
+++ b/src/renderer/components/ft-tooltip/ft-tooltip.css
@@ -92,6 +92,10 @@
   transform: translate(calc(-50% * var(--horizontal-directionality-coefficient)), 1em);
 }
 
+.text.allowNewlines {
+  white-space: pre;
+}
+
 .tooltip {
   display: inline-block;
   position: relative;

--- a/src/renderer/components/ft-tooltip/ft-tooltip.js
+++ b/src/renderer/components/ft-tooltip/ft-tooltip.js
@@ -13,7 +13,11 @@ export default defineComponent({
     tooltip: {
       type: String,
       required: true
-    }
+    },
+    allowNewlines: {
+      type: Boolean,
+      default: false,
+    },
   },
   data() {
     const id = `ft-tooltip-${++idCounter}`

--- a/src/renderer/components/ft-tooltip/ft-tooltip.js
+++ b/src/renderer/components/ft-tooltip/ft-tooltip.js
@@ -2,26 +2,6 @@ import { defineComponent } from 'vue'
 
 let idCounter = 0
 
-function isOutOfViewport(el) {
-  if (el == null) { return {} }
-
-  const bounding = el.getBoundingClientRect()
-  const out = {}
-
-  out.top = bounding.top < 0
-  out.left = bounding.left < 0
-  out.bottom = bounding.bottom > (window.innerHeight || document.documentElement.clientHeight)
-  out.right = bounding.right > (window.innerWidth || document.documentElement.clientWidth)
-  out.horizontal = out.left || out.right
-  out.veritical = out.top || out.bottom
-  out.any = out.top || out.left || out.bottom || out.right
-  out.all = out.top && out.left && out.bottom && out.right
-
-  out.bounding = bounding
-
-  return out
-}
-
 export default defineComponent({
   name: 'FtTooltip',
   props: {
@@ -43,28 +23,7 @@ export default defineComponent({
     const id = `ft-tooltip-${++idCounter}`
 
     return {
-      id,
-      isTooltipOutOfViewportResult: {}
+      id
     }
-  },
-  computed: {
-    tooltipOutsideViewPort() {
-      return this.isTooltipOutOfViewportResult.horizontal
-    },
-  },
-  mounted() {
-    this.updateSizeRelatedStates()
-    window.addEventListener('resize', this.updateSizeRelatedStates)
-  },
-  destroyed() {
-    window.removeEventListener('resize', this.updateSizeRelatedStates)
-  },
-  methods: {
-    updateSizeRelatedStates() {
-      if (this.allowNewlines) {
-        // Only when newlines allowed have issue with wrapping
-        this.isTooltipOutOfViewportResult = isOutOfViewport(this.$refs.tooltip)
-      }
-    },
-  },
+  }
 })

--- a/src/renderer/components/ft-tooltip/ft-tooltip.js
+++ b/src/renderer/components/ft-tooltip/ft-tooltip.js
@@ -2,6 +2,26 @@ import { defineComponent } from 'vue'
 
 let idCounter = 0
 
+function isOutOfViewport(el) {
+  if (el == null) { return {} }
+
+  const bounding = el.getBoundingClientRect()
+  const out = {}
+
+  out.top = bounding.top < 0
+  out.left = bounding.left < 0
+  out.bottom = bounding.bottom > (window.innerHeight || document.documentElement.clientHeight)
+  out.right = bounding.right > (window.innerWidth || document.documentElement.clientWidth)
+  out.horizontal = out.left || out.right
+  out.veritical = out.top || out.bottom
+  out.any = out.top || out.left || out.bottom || out.right
+  out.all = out.top && out.left && out.bottom && out.right
+
+  out.bounding = bounding
+
+  return out
+}
+
 export default defineComponent({
   name: 'FtTooltip',
   props: {
@@ -23,7 +43,28 @@ export default defineComponent({
     const id = `ft-tooltip-${++idCounter}`
 
     return {
-      id
+      id,
+      isTooltipOutOfViewportResult: {}
     }
-  }
+  },
+  computed: {
+    tooltipOutsideViewPort() {
+      return this.isTooltipOutOfViewportResult.horizontal
+    },
+  },
+  mounted() {
+    this.updateSizeRelatedStates()
+    window.addEventListener('resize', this.updateSizeRelatedStates)
+  },
+  destroyed() {
+    window.removeEventListener('resize', this.updateSizeRelatedStates)
+  },
+  methods: {
+    updateSizeRelatedStates() {
+      if (this.allowNewlines) {
+        // Only when newlines allowed have issue with wrapping
+        this.isTooltipOutOfViewportResult = isOutOfViewport(this.$refs.tooltip)
+      }
+    },
+  },
 })

--- a/src/renderer/components/ft-tooltip/ft-tooltip.vue
+++ b/src/renderer/components/ft-tooltip/ft-tooltip.vue
@@ -10,7 +10,10 @@
     <p
       :id="id"
       class="text"
-      :class="position"
+      :class="{
+        [position]: true,
+        allowNewlines,
+      }"
       role="tooltip"
     >
       {{ tooltip }}

--- a/src/renderer/components/ft-tooltip/ft-tooltip.vue
+++ b/src/renderer/components/ft-tooltip/ft-tooltip.vue
@@ -15,8 +15,8 @@
         allowNewlines,
       }"
       role="tooltip"
+      v-text="tooltip"
     >
-      {{ tooltip }}
     </p>
   </div>
 </template>

--- a/src/renderer/components/ft-tooltip/ft-tooltip.vue
+++ b/src/renderer/components/ft-tooltip/ft-tooltip.vue
@@ -9,12 +9,10 @@
     </button>
     <p
       :id="id"
-      ref="tooltip"
       class="text"
       :class="{
         [position]: true,
         allowNewlines,
-        wrap: tooltipOutsideViewPort,
       }"
       role="tooltip"
       v-text="tooltip"

--- a/src/renderer/components/ft-tooltip/ft-tooltip.vue
+++ b/src/renderer/components/ft-tooltip/ft-tooltip.vue
@@ -16,8 +16,7 @@
       }"
       role="tooltip"
       v-text="tooltip"
-    >
-    </p>
+    />
   </div>
 </template>
 

--- a/src/renderer/components/ft-tooltip/ft-tooltip.vue
+++ b/src/renderer/components/ft-tooltip/ft-tooltip.vue
@@ -9,10 +9,12 @@
     </button>
     <p
       :id="id"
+      ref="tooltip"
       class="text"
       :class="{
         [position]: true,
         allowNewlines,
+        wrap: tooltipOutsideViewPort,
       }"
       role="tooltip"
       v-text="tooltip"

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -472,11 +472,13 @@ Settings:
     Export Playlists: Export Playlists
     Export Playlists For Older FreeTube Versions:
       Label: Export Playlists For Older FreeTube Versions
-      Tooltip: Older FreeTube versions cannot import playlist exports from newer versions
-        due to old code and assumption on single playlist.
-        Enable this option & export playlists if you intend to downgrade FreeTube.
-        You should also remove all playlists after export & before downgrade
-        to ensure that the older versions of FreeTube would regenerate playlist data compatible for those versions.
+      # |- = Keep newlines, No newline at end
+      Tooltip: |-
+        This option exports videos from all playlists into one playlist named `Favorites`.
+        How to export & import videos in playlists for an older version of FreeTube:
+        1. Export your playlists with this option enabled.
+        2. Delete all of your existing playlists using the Remove All Playlists option under Privacy Settings.
+        3. Launch the older version of FreeTube and import the exported playlists."
     Profile object has insufficient data, skipping item: Profile object has insufficient
       data, skipping item
     All subscriptions and profiles have been successfully imported: All subscriptions

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -470,6 +470,13 @@ Settings:
     Export History: Export History
     Import Playlists: Import Playlists
     Export Playlists: Export Playlists
+    Export Playlists For Older FreeTube Versions:
+      Label: Export Playlists For Older FreeTube Versions
+      Tooltip: Older FreeTube versions cannot import playlist exports from newer versions
+        due to old code and assumption on single playlist.
+        Enable this option & export playlists if you intend to downgrade FreeTube.
+        You should also remove all playlists after export & before downgrade
+        to ensure that the older versions of FreeTube would regenerate playlist data compatible for those versions.
     Profile object has insufficient data, skipping item: Profile object has insufficient
       data, skipping item
     All subscriptions and profiles have been successfully imported: All subscriptions

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -474,7 +474,7 @@ Settings:
       Label: Export Playlists For Older FreeTube Versions
       # |- = Keep newlines, No newline at end
       Tooltip: |-
-        This option exports videos from all playlists into one playlist named `Favorites`.
+        This option exports videos from all playlists into one playlist named 'Favorites'.
         How to export & import videos in playlists for an older version of FreeTube:
         1. Export your playlists with this option enabled.
         2. Delete all of your existing playlists using the Remove All Playlists option under Privacy Settings.


### PR DESCRIPTION

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Addition to https://github.com/FreeTubeApp/FreeTube/pull/4234

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
New toggle to allow user to export playlists in a format consumable by old versions of FT

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
![image](https://github.com/FreeTubeApp/FreeTube/assets/1018543/5b173a90-f457-4006-9690-33e2292991a4)

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
- Checkout this PR, add some playlists and videos, probably also removed the default playlists
- Export playlists as usual (also as backup file for different tests
- Export playlists with new toggle on
- Remove all playlists
- Switch back to `development`, import the export with new toggle on
- Confirm all videos from all playlists are present

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
